### PR TITLE
merge fix-ramp-workflow into development

### DIFF
--- a/script/ingest_worldcat.js
+++ b/script/ingest_worldcat.js
@@ -187,7 +187,11 @@ function ingest_worldcat_elements(lobjEac, lstrName, callback) {
 
                             $('.form_container').remove();
 
+                            hideLoadingImage();
+                            
                             editor.getSession().setValue(lobjEac.getXML());
+
+                            viewSwitch.showAceEditor();
                             return;
                         } else {
 


### PR DESCRIPTION
[d9d439f] show editor and remove loading image when no world cat matching subjects is triggered. ingest_worldcat.js line 190