### PR TITLE
merge into development - added html_entity_decode() to wiki search snippet

### DIFF
--- a/lib/RAMP/Wiki/Wikiator.php
+++ b/lib/RAMP/Wiki/Wikiator.php
@@ -176,7 +176,7 @@ class Wikiator
 		{
 			$lstrEncodedTitle = self::encodeForUrl($lobjSearchList[$i]['title']);
 
-			$lobjSearchList[$i]['snippet'] = $lobjMatch[1][$i] . "<br/><a target=\"_blank\" href=\"https://en.wikipedia.org/wiki/{$lstrEncodedTitle}\">View existing Wikipedia page</a>";
+			$lobjSearchList[$i]['snippet'] = html_entity_decode($lobjMatch[1][$i]) . "<br/><a target=\"_blank\" href=\"https://en.wikipedia.org/wiki/{$lstrEncodedTitle}\">View existing Wikipedia page</a>";
 		}
 
 		$lobjMatch = array();


### PR DESCRIPTION
[01e1e1a] added html_entity_decode() to wiki search snippet so that html markup is not displayed in search results